### PR TITLE
use full wazo name for entry points

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     url='http://wazo.community',
     packages=find_packages(),
     entry_points={
-        'auth_client.commands': [
+        'wazo_auth_client.commands': [
             'admin = wazo_auth_client.commands.admin:AdminCommand',
             'emails = wazo_auth_client.commands.emails:EmailsCommand',
             'external = wazo_auth_client.commands.external:ExternalAuthCommand',

--- a/wazo_auth_client/client.py
+++ b/wazo_auth_client/client.py
@@ -9,7 +9,7 @@ from wazo_lib_rest_client.client import BaseClient
 
 class AuthClient(BaseClient):
 
-    namespace = 'auth_client.commands'
+    namespace = 'wazo_auth_client.commands'
 
     def __init__(
         self,


### PR DESCRIPTION
reason: entry points are global to the system, so if you have
xivo_auth_client and wazo_auth_client installed, then the entry points
loaded can be chosen randomly