### PR TITLE
Add the capacity to remove a tenant from another tenant

### DIFF
--- a/wazo_auth_client/commands/tenants.py
+++ b/wazo_auth_client/commands/tenants.py
@@ -19,10 +19,15 @@ class TenantsCommand(RESTCommand):
         if r.status_code != 204:
             self.raise_from_response(r)
 
-    def delete(self, tenant_uuid):
-        url = '{}/{}'.format(self.base_url, tenant_uuid)
+    def delete(self, uuid, tenant_uuid=None):
+        url = '{}/{}'.format(self.base_url, uuid)
+        headers = dict(self._ro_headers)
 
-        r = self.session.delete(url, headers=self._ro_headers)
+        tenant_uuid = tenant_uuid or self._client.tenant()
+        if tenant_uuid:
+            headers['Wazo-Tenant'] = tenant_uuid
+
+        r = self.session.delete(url, headers=headers)
 
         if r.status_code != 204:
             self.raise_from_response(r)


### PR DESCRIPTION
In wazo UI, it's not possible to remove a tenant from the global settings. This PR need to be merged to fix this issue on wazo-ui.