### PR TITLE
Use Python 3.9, new workers, and Bullseye dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends:
  python3-all,
  python3-setuptools
 Standards-Version: 3.9.6
-X-Python3-Version: >= 3.7
+X-Python3-Version: >= 3.9
 
 Package: wazo-auth-client-python3
 Architecture: all

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 https://github.com/wazo-platform/wazo-lib-rest-client/archive/bullseye.zip
-requests==2.21.0
-stevedore==1.29.0
+requests==2.25.1
+stevedore==3.2.2

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,12 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, linters
-skipsdist=True
+envlist = py39, linters
+skipsdist = True
 
 [testenv]
 commands =
-    pytest wazo_auth_client
+    pytest wazo_auth_client {posargs}
 deps =
     -rrequirements.txt
     -rtest-requirements.txt
@@ -20,8 +20,8 @@ deps = black
 commands = black --skip-string-normalization .
 
 [testenv:linters]
+basepython = python3.10
 skip_install = true
-basepython = python3.7
 deps =
     flake8
     flake8-colors

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -1,5 +1,5 @@
 - project:
     templates:
-      - wazo-tox-linters
-      - wazo-tox-py37
-      - debian-packaging-template
+      - wazo-tox-linters-310
+      - wazo-tox-py39
+      - debian-packaging-bullseye


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-lib-rest-client/pull/14