### PR TITLE
add TokenDict typing

### DIFF
--- a/wazo_auth_client/types.py
+++ b/wazo_auth_client/types.py
@@ -1,0 +1,33 @@
+# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class TokenMetadataDict(TypedDict):
+    uuid: str
+    tenant_uuid: str
+    auth_id: str
+    pbx_user_uuid: str
+    xivo_uuid: str
+
+
+class TokenMetadataStackDict(TokenMetadataDict, total=False):
+    purpose: str
+    admin: str
+
+
+class TokenDict(TypedDict):
+    token: str
+    session_uuid: str
+    metadata: TokenMetadataDict
+    acl: list[str]
+    auth_id: str
+    xivo_uuid: str
+    expires_at: str
+    utc_expires_at: str
+    issued_at: str
+    utc_issued_at: str
+    user_agent: str
+    remote_addr: str


### PR DESCRIPTION
note: for now, it's only used by third party to scope the time invested.
But it should be used by wazo_auth_client too