### PR TITLE
remove-unused-basicauth

### DIFF
--- a/wazo_auth_client/client.py
+++ b/wazo_auth_client/client.py
@@ -1,12 +1,10 @@
-# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
 from typing import Any
 
-import requests
-import requests.auth
 from wazo_lib_rest_client.client import BaseClient
 
 from wazo_auth_client.commands import (
@@ -64,11 +62,3 @@ class AuthClient(BaseClient):
         super().__init__(host=host, port=port, prefix=prefix, version=version, **kwargs)
         self.username = username
         self.password = password
-
-    def session(self) -> requests.Session:
-        session = super().session()
-        if self.username and self.password:
-            session.auth = requests.auth.HTTPBasicAuth(
-                self.username.encode("utf-8"), self.password.encode("utf-8")
-            )
-        return session

--- a/wazo_auth_client/commands/tests/test_token.py
+++ b/wazo_auth_client/commands/tests/test_token.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -20,7 +20,7 @@ class TestTokenCommand(TestCase):
     def setUp(self) -> None:
         self.client = Client('host', port=9497, prefix=None, https=False)
         # NOTE(clanglois): can use patch.object instead of manual monkey patching
-        self.client.session = MagicMock()  # type: ignore
+        self.client.session = MagicMock()
         self.session = self.client.session.return_value
         self.command = TokenCommand(self.client)
 
@@ -44,7 +44,7 @@ class TestTokenCreate(TestTokenCommand):
         self.session = requests.Session()
         self.stack = ExitStack()
         self.stack.enter_context(patch.object(self.session, 'send'))
-        self.client.session = MagicMock(return_value=self.session)  # type: ignore
+        self.client.session = MagicMock(return_value=self.session)
 
     def tearDown(self) -> None:
         self.stack.close()

--- a/wazo_auth_client/commands/token.py
+++ b/wazo_auth_client/commands/token.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -54,11 +54,9 @@ class TokenCommand(RESTCommand):
         if user_agent:
             headers['User-Agent'] = user_agent
 
-        auth = self.session.auth
-        if username and password:
-            auth = requests.auth.HTTPBasicAuth(
-                username.encode('utf-8'), password.encode('utf-8')
-            )
+        username_encoded = (username or self._client.username or '').encode('utf-8')
+        password_encoded = (password or self._client.password or '').encode('utf-8')
+        auth = requests.auth.HTTPBasicAuth(username_encoded, password_encoded)
         r = self.session.post(self.base_url, headers=headers, json=data, auth=auth)
 
         if r.status_code != 200:


### PR DESCRIPTION
why: only used on POST /token
