### PR TITLE
Bump mypy pre-commit hook to v1.19.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     hooks:
       - id: wazo-copyright-check
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.6.1
+    rev: v1.19.1
     hooks:
       - id: mypy
         language_version: "3.11"


### PR DESCRIPTION
Resolves compatibility issues with latest types-setuptools.
See WAZO-4386.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the mypy pre-commit hook to a newer version.
> 
> - Upgrades `pre-commit` mypy mirror in `.pre-commit-config.yaml` from `v1.6.1` to `v1.19.1`
> - No other configuration changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c53dbc96e7d4bc5a04c52ab343cbd2252c090b4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->