### PR TITLE
NES-2728-auth-parent-uuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,9 @@ c.tenants.new(name='<new tenant name>')
 # Updating a tenant
 c.tenants.edit('<tenant_uuid>', name='<new tenant name>')
 
+# Updating a tenant parent
+c.tenants.update_parent('<tenant_uuid>', '<new_parent_uuid>')
+
 # External authentification storage
 c.external.create('<auth_service>', '<user_uuid>', {'key': 'value'})
 c.external.update('<auth_service>', '<user_uuid>', {'key': 'value'})

--- a/wazo_auth_client/commands/tenants.py
+++ b/wazo_auth_client/commands/tenants.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -74,3 +74,10 @@ class TenantsCommand(RESTCommand):
         if r.status_code != 200:
             self.raise_from_response(r)
         return r.json()
+
+    def update_parent(self, tenant_uuid: str, parent_uuid: str) -> None:
+        headers = self._get_headers()
+        url = f'{self.base_url}/{tenant_uuid}/parent/{parent_uuid}'
+        r = self.session.put(url, headers=headers)
+        if r.status_code != 204:
+            self.raise_from_response(r)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small additive client change that introduces a new REST call and documentation update; limited blast radius aside from potential API path/response-code mismatches.
> 
> **Overview**
> Adds `TenantsCommand.update_parent(tenant_uuid, parent_uuid)` to update a tenant’s parent via `PUT /tenants/{tenant_uuid}/parent/{parent_uuid}`, expecting a `204` response.
> 
> Updates the README tenant usage examples to document the new `c.tenants.update_parent(...)` call, and bumps the copyright year range in `tenants.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eeb1f2239221274c19040cded8f42a0eb353ff0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->